### PR TITLE
Don't throw exceptions on port not managed by us

### DIFF
--- a/networking_f5/plugins/ml2/drivers/mech_f5/driver.py
+++ b/networking_f5/plugins/ml2/drivers/mech_f5/driver.py
@@ -136,9 +136,10 @@ class F5MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase,
 
         # Only accept listener_ips
         if context.current['device_owner'] != constants.DEVICE_OWNER_LISTENER:
-            raise Exception(
-                "Port '{}' has not a valid owner description".format(
-                    context.current['id']))
+            LOG.debug("Port '{}' has not a valid owner description, "
+                      "not managed by us."
+                      .format(context.current['id']))
+            return
 
         # Need at least one ip address assigned
         if len(context.current['fixed_ips']) < 1:


### PR DESCRIPTION
If a port is not managed by this driver it now no longer raises an
exception and just returns and lets another driver handle it.