### PR TITLE
Match port/net argument order to LOG entry

### DIFF
--- a/networking_f5/plugins/ml2/drivers/mech_f5/rpc.py
+++ b/networking_f5/plugins/ml2/drivers/mech_f5/rpc.py
@@ -64,7 +64,7 @@ class F5DORpcCallback(object):
             if not port.binding_levels:
                 LOG.warning("No bindings for port %s (network %s) found, "
                             "cannot configure F5 layer2 access.",
-                            port.network_id, port.id)
+                            port.id, port.network_id)
                 continue
 
             # Use vlan segments associated with exactly this port


### PR DESCRIPTION
Old version used network id as port and port id as network.